### PR TITLE
Python 3.7 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,124 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/pygaze/_display/psychopydisplay.py
+++ b/pygaze/_display/psychopydisplay.py
@@ -65,16 +65,16 @@ class PsychoPyDisplay:
                 self.monitor = monitor
 
 				# create window
-				pygaze.expdisplay = Window(size=self.dispsize, pos=None,
-						color=rgb2psychorgb(self.bgc), colorSpace='rgb',
-						fullscr=settings.FULLSCREEN, monitor=self.monitor, 
-						screen=self.screennr, units='pix', winType='pygame')
-				# set mouse visibility
-				pygaze.expdisplay.setMouseVisible(self.mousevis)
-				# get screen in window
-				if screen:
-					for s in screen.screen:
-						s.draw()
+                pygaze.expdisplay = Window(size=self.dispsize, pos=None,
+                        color=rgb2psychorgb(self.bgc), colorSpace='rgb',
+                        fullscr=settings.FULLSCREEN, monitor=self.monitor, 
+                        screen=self.screennr, units='pix', winType='pygame')
+                # set mouse visibility
+                pygaze.expdisplay.setMouseVisible(self.mousevis)
+                # get screen in window
+                if screen:
+                    for s in screen.screen:
+                        s.draw()
 
         def show(self):
 

--- a/pygaze/_display/psychopydisplay.py
+++ b/pygaze/_display/psychopydisplay.py
@@ -25,6 +25,7 @@ from pygaze._misc.misc import rgb2psychorgb
 from pygaze.libtime import clock
 #from pygaze._display.basedisplay import BaseDisplay
 
+import pygame
 from psychopy.visual import Window
 
 # we try importing the copy_docstr function, but as we do not really need it
@@ -63,17 +64,17 @@ class PsychoPyDisplay:
                 self.mousevis = False
                 self.monitor = monitor
 
-                # create window
-                pygaze.expdisplay = Window(size=self.dispsize, pos=None,
-                        color=rgb2psychorgb(self.bgc), colorSpace='rgb',
-                        fullscr=settings.FULLSCREEN, monitor=self.monitor, 
-                        screen=self.screennr, units='pix')
-                # set mouse visibility
-                pygaze.expdisplay.setMouseVisible(self.mousevis)
-                # get screen in window
-                if screen:
-                    for s in screen.screen:
-                        s.draw()
+				# create window
+				pygaze.expdisplay = Window(size=self.dispsize, pos=None,
+						color=rgb2psychorgb(self.bgc), colorSpace='rgb',
+						fullscr=settings.FULLSCREEN, monitor=self.monitor, 
+						screen=self.screennr, units='pix', winType='pygame')
+				# set mouse visibility
+				pygaze.expdisplay.setMouseVisible(self.mousevis)
+				# get screen in window
+				if screen:
+					for s in screen.screen:
+						s.draw()
 
         def show(self):
 

--- a/pygaze/_display/psychopydisplay.py
+++ b/pygaze/_display/psychopydisplay.py
@@ -25,7 +25,6 @@ from pygaze._misc.misc import rgb2psychorgb
 from pygaze.libtime import clock
 #from pygaze._display.basedisplay import BaseDisplay
 
-import pygame
 from psychopy.visual import Window
 
 # we try importing the copy_docstr function, but as we do not really need it
@@ -64,11 +63,11 @@ class PsychoPyDisplay:
                 self.mousevis = False
                 self.monitor = monitor
 
-				# create window
+                # create window
                 pygaze.expdisplay = Window(size=self.dispsize, pos=None,
                         color=rgb2psychorgb(self.bgc), colorSpace='rgb',
                         fullscr=settings.FULLSCREEN, monitor=self.monitor, 
-                        screen=self.screennr, units='pix', winType='pygame')
+                        screen=self.screennr, units='pix')
                 # set mouse visibility
                 pygaze.expdisplay.setMouseVisible(self.mousevis)
                 # get screen in window

--- a/pygaze/_eyetracker/eyelinkgraphics.py
+++ b/pygaze/_eyetracker/eyelinkgraphics.py
@@ -465,7 +465,7 @@ class EyelinkGraphics(custom_display):
 		msg		--	The message to be played.
 		"""
 
-		print "eyelink_graphics.alert_printf(): %s" % msg
+		print("eyelink_graphics.alert_printf(): %s" % msg)
 
 	def setup_image_display(self, width, height):
 

--- a/pygaze/_eyetracker/iViewXAPI.py
+++ b/pygaze/_eyetracker/iViewXAPI.py
@@ -83,7 +83,7 @@ calibrationData = CCalibration(5, 1, 0, 0, 1, 20, 239, 1, 15, b"")
 leftEye = CEye(0,0,0)
 rightEye = CEye(0,0,0)
 sampleData = CSample(0,leftEye,rightEye,0)
-eventData = CEvent('F', 'L', 0, 0, 0, 0, 0)
+eventData = CEvent(b'F', b'L', 0, 0, 0, 0, 0)
 accuracyData = CAccuracy(0,0,0,0)
 
 

--- a/pygaze/_eyetracker/libsmi.py
+++ b/pygaze/_eyetracker/libsmi.py
@@ -39,7 +39,7 @@ except:
 import copy
 import math
 
-from iViewXAPI import  *
+from pygaze._eyetracker.iViewXAPI import  *
 
 
 # function for identyfing errors

--- a/pygaze/_eyetracker/libtobiilegacy.py
+++ b/pygaze/_eyetracker/libtobiilegacy.py
@@ -1330,7 +1330,7 @@ class TobiiController:
 		"""
 		
 		eyetracker_info = self.eyetrackers[eyetracker]
-		print "Connecting to:", eyetracker_info
+		print("Connecting to:", eyetracker_info)
 		tobii.eye_tracking_io.eyetracker.Eyetracker.create_async(self.mainloop_thread,
 													 eyetracker_info,
 													 lambda error, eyetracker: self.on_eyetracker_created(error, eyetracker, eyetracker_info))
@@ -1419,7 +1419,7 @@ class TobiiController:
 		
 		# start calibration
 		self.initcalibration_completed = False
-		print "StartCalibration"
+		print("StartCalibration")
 		self.eyetracker.StartCalibration(lambda error, r: self.on_calib_start(error, r))
 		while not self.initcalibration_completed:
 			pass
@@ -1628,7 +1628,7 @@ class TobiiController:
 			print("WARNING! libtobii.TobiiController.on_calib_compute: Could not compute calibration because of a server error.\n\n<b>Details:</b>\n<i>%s</i>" % (error))
 			raise Exception("Error in libtobii.TobiiController.on_calib.compute: CalibCompute failed because of a server error:", error)
 		else:
-			print ""
+			print("")
 			self.computeCalibration_succeeded = True
 		
 		self.computeCalibration_completed = True
@@ -1662,7 +1662,7 @@ class TobiiController:
 			self.getcalibration_completed = True
 			return False
 		
-		print "On_calib_response: Success"
+		print("On_calib_response: Success")
 		self.calib = calib
 		self.getcalibration_completed = True
 		return False	
@@ -1854,7 +1854,7 @@ class TobiiController:
 		None		--	sets self.datafile to an open textfile
 		"""
 		
-		print 'set datafile ' + filename
+		print('set datafile ' + filename)
 		self.datafile = open(filename,'w')
 		self.datafile.write('Recording date:\t'+datetime.datetime.now().strftime('%Y/%m/%d')+'\n')
 		self.datafile.write('Recording time:\t'+datetime.datetime.now().strftime('%H:%M:%S')+'\n')
@@ -1876,7 +1876,7 @@ class TobiiController:
 					self.datafile and sets self.datafile to None
 		"""
 		
-		print 'datafile closed'
+		print('datafile closed')
 		if self.datafile != None:
 			self.flushData()
 			self.datafile.close()

--- a/pygaze/defaults.py
+++ b/pygaze/defaults.py
@@ -26,7 +26,7 @@ LOGFILE = LOGFILENAME[:] # .txt; adding path before logfilename is optional; log
 
 # DISPLAY
 SCREENNR = 0 # number of the screen used for displaying experiment
-DISPTYPE = 'psychopy' # either 'psychopy' or 'pygame'
+DISPTYPE = 'pygame' # either 'psychopy' or 'pygame'
 DISPSIZE = (1280,1024) # canvas size
 SCREENSIZE = (33.8,27.1) # physical screen size in centimeters
 SCREENDIST = 57.0 # centimeters; distance between screen and participant's eyes

--- a/pygaze/libgazecon.py
+++ b/pygaze/libgazecon.py
@@ -19,6 +19,6 @@
 #	You should have received a copy of the GNU General Public License
 #	along with this program.  If not, see <http://www.gnu.org/licenses/>
 
-from plugins.aoi import AOI
-from plugins.frl import FRL
-from plugins.gazecursor import GazeCursor as Cursor
+from pygaze.plugins.aoi import AOI
+from pygaze.plugins.frl import FRL
+from pygaze.plugins.gazecursor import GazeCursor as Cursor

--- a/pygaze/liblog.py
+++ b/pygaze/liblog.py
@@ -19,4 +19,4 @@
 #	You should have received a copy of the GNU General Public License
 #	along with this program.  If not, see <http://www.gnu.org/licenses/>
 
-from logfile import Logfile
+from pygaze.logfile import Logfile

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,9 @@ def data_files():
 		("share/opensesame_plugins/pygaze_stop_recording",
 			files("opensesame_plugins/pygaze_stop_recording/*")),
 		("share/opensesame_plugins/pygaze_wait",
-			files("opensesame_plugins/pygaze_wait/*"))
+			files("opensesame_plugins/pygaze_wait/*")),
+		("pygaze/resources/fonts",
+			files("resources/fonts/*"))
 		]
 
 setup(


### PR DESCRIPTION
I found a few places where Python 2's print syntax was still used, and some places where the import statements wouldn't work after installing the package.
I also switched psychopy's backend from pyglet to pygame since pyglet isn't compatible with Python 3.

With those changes, I was able to install PyGaze to my computer and use it in Python 3 modules.